### PR TITLE
fix: make debug logging work and not cause infinite updates

### DIFF
--- a/packages/timeline-state-resolver/src/service/ConnectionManager.ts
+++ b/packages/timeline-state-resolver/src/service/ConnectionManager.ts
@@ -108,10 +108,7 @@ export class ConnectionManager extends EventEmitter<ConnectionManagerEvents> {
 				// see if it should be restarted because of an update
 				if (connectionConfigHasChanged(connection, config)) {
 					operations.push({ operation: 'update', id: deviceId })
-				} else if (
-					connection.deviceOptions.debug !== config.debug ||
-					connection.deviceOptions.debugState !== config.debugState
-				) {
+				} else if (connection.debugLogging !== !!config.debug || connection.debugState !== !!config.debugState) {
 					// see if we should set the debug params
 					operations.push({ operation: 'setDebug', id: deviceId })
 				}
@@ -304,8 +301,8 @@ export class ConnectionManager extends EventEmitter<ConnectionManagerEvents> {
 		if (!connection || !config) return
 
 		try {
-			await connection.device.setDebugLogging(config.debug ?? false)
-			await connection.device.setDebugState(config.debugState ?? false)
+			await connection.setDebugLogging(!!config.debug)
+			await connection.setDebugState(!!config.debugState)
 		} catch {
 			this.emit('warning', 'Failed to update debug values for ' + id)
 		}


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This pull request is posted on behalf of TV 2 Norge

## Type of Contribution

This is a: 
<!-- (pick one) -->
Bug fix


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->
The `Activate debug logging for device` option seemingly does nothing. No debug logs are printed when toggled on. However, when toggled while a device is already enabled, it causes an infinite sequence of update operations.

## New Behavior
<!--
What is the new behavior?
-->
Debug logging works, and the operation updates properties needed for later comparison with potentially changed options. Null/undefined values are treated correctly.

## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->

- Enable a device after setting `Activate debug logging for device` option to on and off. Check if there's a difference in logs depending on the value.
- While a device is enabled, toggle `Activate debug logging for device` option on and off. Check if there's a difference in logs depending on the value.

In both cases, a device capable of outputting debug logs should be used, and playout actions should be performed in order to provoke the logs.

## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->
Draft. Might add unit tests

## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
