### PR TITLE
Bug in commandExecutor: `.preliminary` does not work (SOFIE-4069)

### DIFF
--- a/packages/timeline-state-resolver/src/service/__tests__/commandExecutor.spec.ts
+++ b/packages/timeline-state-resolver/src/service/__tests__/commandExecutor.spec.ts
@@ -1,0 +1,193 @@
+import { waitTime } from '../../__tests__/lib'
+import { CommandExecutor } from '../commandExecutor'
+
+describe('CommandExecutor', () => {
+	const FUDGE_TIME = 50 // ms
+	const logger = {
+		info: jest.fn(console.log),
+		warn: jest.fn(console.warn),
+		error: jest.fn(console.warn),
+		debug: jest.fn(console.log),
+	}
+	let startTime = Date.now()
+	let timeToExecuteCommand = 0
+	let receivedCommandTimes: { [cmd: string]: number } = {}
+	const sendCommand = jest.fn(async (cmd) => {
+		receivedCommandTimes[cmd.command] = Date.now() - startTime
+		if (timeToExecuteCommand > 0) await waitTime(timeToExecuteCommand)
+	})
+
+	beforeEach(() => {
+		receivedCommandTimes = {}
+		timeToExecuteCommand = 0
+		sendCommand.mockClear()
+	})
+	test('salvo commands', async () => {
+		timeToExecuteCommand = 100 // ms
+		const commandExecutor = new CommandExecutor(logger, 'salvo', sendCommand)
+
+		startTime = Date.now()
+		await commandExecutor.executeCommands([
+			{ command: 'A0' },
+			{ command: 'A1' },
+			{ command: 'A2' },
+			{ command: 'A3' },
+			{ command: 'A4' },
+		])
+
+		expect(sendCommand).toHaveBeenCalledTimes(5)
+		expect(Math.abs(receivedCommandTimes['A0'] - 0)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['A1'] - 0)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['A2'] - 0)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['A3'] - 0)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['A4'] - 0)).toBeLessThan(FUDGE_TIME)
+	})
+	test('salvo commands, with preliminary', async () => {
+		timeToExecuteCommand = 100 // ms
+		const commandExecutor = new CommandExecutor(logger, 'salvo', sendCommand)
+
+		startTime = Date.now()
+		await commandExecutor.executeCommands([
+			{ command: 'A0' },
+			{ command: 'A1' },
+			{ command: 'A-p200', preliminary: 200 },
+			{ command: 'A-p500', preliminary: 500 },
+		])
+
+		expect(sendCommand).toHaveBeenCalledTimes(4)
+		expect(Math.abs(receivedCommandTimes['A-p500'] - 0)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['A-p200'] - 300)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['A0'] - 500)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['A1'] - 500)).toBeLessThan(FUDGE_TIME)
+	})
+	test('sequential commands', async () => {
+		timeToExecuteCommand = 100 // ms
+		const commandExecutor = new CommandExecutor(logger, 'sequential', sendCommand)
+
+		startTime = Date.now()
+		await commandExecutor.executeCommands([
+			{ command: 'A0' },
+			{ command: 'A1' },
+			{ command: 'A2' },
+			{ command: 'A3' },
+			{ command: 'A4' },
+		])
+
+		expect(sendCommand).toHaveBeenCalledTimes(5)
+		expect(Math.abs(receivedCommandTimes['A0'] - 0)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['A1'] - 100)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['A2'] - 200)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['A3'] - 300)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['A4'] - 400)).toBeLessThan(FUDGE_TIME)
+	})
+	test('sequential commands, multiple queues', async () => {
+		timeToExecuteCommand = 100 // ms
+		const commandExecutor = new CommandExecutor(logger, 'sequential', sendCommand)
+
+		startTime = Date.now()
+		await commandExecutor.executeCommands([
+			{ command: 'A0', queueId: 'queueA' },
+			{ command: 'A1', queueId: 'queueA' },
+			{ command: 'A2', queueId: 'queueA' },
+			{ command: 'A3', queueId: 'queueA' },
+			{ command: 'A4', queueId: 'queueA' },
+			{ command: 'B0', queueId: 'queueB' },
+			{ command: 'B1', queueId: 'queueB' },
+			{ command: 'B2', queueId: 'queueB' },
+			{ command: 'B3', queueId: 'queueB' },
+			{ command: 'B4', queueId: 'queueB' },
+		])
+
+		expect(sendCommand).toHaveBeenCalledTimes(10)
+		expect(Math.abs(receivedCommandTimes['A0'] - 0)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['A1'] - 100)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['A2'] - 200)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['A3'] - 300)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['A4'] - 400)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['B0'] - 0)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['B1'] - 100)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['B2'] - 200)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['B3'] - 300)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['B4'] - 400)).toBeLessThan(FUDGE_TIME)
+	})
+	test('sequential commands, with preliminary', async () => {
+		timeToExecuteCommand = 100 // ms
+		const commandExecutor = new CommandExecutor(logger, 'sequential', sendCommand)
+
+		startTime = Date.now()
+		await commandExecutor.executeCommands([
+			{ command: 'A0' },
+			{ command: 'A1' },
+			{ command: 'A2' },
+			{ command: 'A3' },
+			{ command: 'Ap100', preliminary: 200 },
+			{ command: 'Ap200', preliminary: 300 },
+		])
+
+		expect(sendCommand).toHaveBeenCalledTimes(6)
+		expect(Math.abs(receivedCommandTimes['Ap200'] - 0)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['Ap100'] - 100)).toBeLessThan(FUDGE_TIME)
+		// The rest are delayed:
+		expect(Math.abs(receivedCommandTimes['A0'] - 300)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['A1'] - 400)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['A2'] - 500)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['A3'] - 600)).toBeLessThan(FUDGE_TIME)
+	})
+	test('sequential with preliminary, in multiple queues', async () => {
+		const commandExecutor = new CommandExecutor(logger, 'sequential', sendCommand)
+
+		startTime = Date.now()
+		await commandExecutor.executeCommands([
+			// Commands are 2 queues, A and B
+			// in random order, with preliminary times
+			{
+				command: 'A-0',
+				queueId: 'queueA',
+			},
+			{
+				command: 'A-300',
+				queueId: 'queueA',
+				preliminary: 300,
+			},
+			{
+				command: 'B-300',
+				queueId: 'queueB',
+				preliminary: 300,
+			},
+			{
+				command: 'A-1000',
+				queueId: 'queueA',
+				preliminary: 1000,
+			},
+			{
+				command: 'B-1000',
+				queueId: 'queueB',
+				preliminary: 1000,
+			},
+			{
+				command: 'B-500',
+				queueId: 'queueB',
+				preliminary: 500,
+			},
+			{
+				command: 'A-500',
+				queueId: 'queueA',
+				preliminary: 500,
+			},
+			{
+				command: 'B-0',
+				queueId: 'queueB',
+			},
+		])
+
+		expect(sendCommand).toHaveBeenCalledTimes(8)
+		expect(Math.abs(receivedCommandTimes['A-1000'] - 0)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['B-1000'] - 0)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['B-500'] - 500)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['A-500'] - 500)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['A-300'] - 700)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['B-300'] - 700)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['A-0'] - 1000)).toBeLessThan(FUDGE_TIME)
+		expect(Math.abs(receivedCommandTimes['B-0'] - 1000)).toBeLessThan(FUDGE_TIME)
+	})
+})

--- a/packages/timeline-state-resolver/src/service/commandExecutor.ts
+++ b/packages/timeline-state-resolver/src/service/commandExecutor.ts
@@ -3,8 +3,6 @@ import { BaseDeviceAPI, CommandWithContext } from './device'
 import { Measurement } from './measure'
 import { StateHandlerContext } from './stateHandler'
 
-const wait = async (t: number) => new Promise<void>((r) => setTimeout(() => r(), t))
-
 export class CommandExecutor<DeviceState, Command extends CommandWithContext> {
 	constructor(
 		private logger: StateHandlerContext['logger'],
@@ -15,7 +13,9 @@ export class CommandExecutor<DeviceState, Command extends CommandWithContext> {
 	async executeCommands(commands: Command[], measurement?: Measurement): Promise<void> {
 		if (commands.length === 0) return
 
+		// Sort the commands, so that the ones with the highest preliminary time are executed first.
 		commands.sort((a, b) => (b.preliminary ?? 0) - (a.preliminary ?? 0))
+
 		const totalTime = commands[0].preliminary ?? 0
 
 		if (this.mode === 'salvo') {
@@ -30,16 +30,27 @@ export class CommandExecutor<DeviceState, Command extends CommandWithContext> {
 		commands: Command[],
 		measurement?: Measurement
 	): Promise<void> {
+		const start = Date.now() // note - would be better to use monotonic time here but BigInt's are annoying
+
 		await Promise.allSettled(
 			commands.map(async (command) => {
-				const timeToWait = totalTime - (command.preliminary ?? 0)
-				if (timeToWait > 0) await wait(totalTime)
+				const targetTime = start + totalTime - (command.preliminary ?? 0)
+
+				const timeToWait = targetTime - Date.now()
+				if (timeToWait > 0) {
+					await sleep(timeToWait)
+				}
 
 				measurement?.executeCommand(command)
-				return this.sendCommand(command).then(() => {
+				let result: unknown
+				try {
+					result = await this.sendCommand(command)
+				} catch (e) {
+					this.logger.error('Error while executing command', e as any)
+				} finally {
 					measurement?.finishedCommandExecution(command)
-					return command
-				})
+				}
+				return result
 			})
 		)
 	}
@@ -55,17 +66,31 @@ export class CommandExecutor<DeviceState, Command extends CommandWithContext> {
 
 		await Promise.allSettled(
 			Object.values<Command[]>(commandQueues).map(async (commandsInQueue): Promise<void> => {
-				for (const command of commandsInQueue) {
-					const timeToWait = totalTime - (Date.now() - start)
-					if (timeToWait > 0) await wait(timeToWait)
+				try {
+					for (const command of commandsInQueue) {
+						const targetTime = start + totalTime - (command.preliminary ?? 0)
 
-					measurement?.executeCommand(command)
-					await this.sendCommand(command).catch((e) => {
-						this.logger.error('Error while executing command', e)
-					})
-					measurement?.finishedCommandExecution(command)
+						const timeToWait = targetTime - Date.now()
+						if (timeToWait > 0) {
+							await sleep(timeToWait)
+						}
+
+						measurement?.executeCommand(command)
+						try {
+							await this.sendCommand(command)
+						} catch (e) {
+							this.logger.error('Error while executing command', e as any)
+						} finally {
+							measurement?.finishedCommandExecution(command)
+						}
+					}
+				} catch (e) {
+					this.logger.error('CommandExecutor', new Error('Error in _executeCommandsSequential'))
 				}
 			})
 		)
 	}
+}
+async function sleep(duration: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, duration))
 }


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->

This pull request is posted on behalf of the NRK

## Type of Contribution

This is a: Bug fix


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

The CommandExecutor did not execute commands properly if the `.preliminary` property was set.


## New Behavior
<!--
What is the new behavior?
-->

(Added unit tests to verify that) CommandExectur now executes commands as expected.


## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->

Currently only the Quantel device uses the `preliminary` property, so testing with respect to Quantel playout is prudent.


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
… executed properly