### PR TITLE
fix: remove DeviceOptionsAnyInternal type from public api

### DIFF
--- a/packages/timeline-state-resolver/src/__tests__/lib.ts
+++ b/packages/timeline-state-resolver/src/__tests__/lib.ts
@@ -1,6 +1,17 @@
-import { DeviceOptionsAnyInternal } from '../conductor'
+import type { DeviceOptionsAny } from 'timeline-state-resolver-types'
 import { ConnectionManager } from '../service/ConnectionManager'
 import { MockTime } from './mockTime'
+import type { DeviceOptionsSisyfosInternal } from '../integrations/sisyfos'
+import type { DeviceOptionsVMixInternal } from '../integrations/vmix'
+import type { DeviceOptionsVizMSEInternal } from '../integrations/vizMSE'
+import type { DeviceOptionsCasparCGInternal } from '../integrations/casparCG'
+
+export type DeviceOptionsAnyInternal =
+	| DeviceOptionsAny
+	| DeviceOptionsSisyfosInternal
+	| DeviceOptionsVMixInternal
+	| DeviceOptionsVizMSEInternal
+	| DeviceOptionsCasparCGInternal
 
 /**
  * Just a wrapper to :any type, to be used in tests only
@@ -43,7 +54,7 @@ export async function addConnections(
 
 export async function removeConnections(
 	connManager: ConnectionManager,
-	connections: Record<string, DeviceOptionsAnyInternal>,
+	connections: Record<string, DeviceOptionsAny>,
 	toBeRemoved: string[]
 ): Promise<void> {
 	const addedConns: string[] = []

--- a/packages/timeline-state-resolver/src/__tests__/mockDeviceInstanceWrapper.ts
+++ b/packages/timeline-state-resolver/src/__tests__/mockDeviceInstanceWrapper.ts
@@ -5,10 +5,10 @@ import {
 	TSRTimelineContent,
 	Mappings,
 	DeviceStatus,
+	DeviceOptionsAny,
 } from 'timeline-state-resolver-types'
 import type { DeviceEvents } from '../service/device'
 import type { DeviceInstanceWrapper, DeviceDetails } from '../service/DeviceInstance'
-import type { DeviceOptionsAnyInternal } from '../conductor'
 import type { ExpectedPlayoutItem } from '../expectedPlayoutItems'
 
 export const ConstructedMockDevices: Record<string, MockDeviceInstanceWrapper> = {}
@@ -41,7 +41,7 @@ export class MockDeviceInstanceWrapper
 		public readonly deviceId: string,
 		_startTime: string,
 		public readonly pluginPath,
-		public readonly config: DeviceOptionsAnyInternal
+		public readonly config: DeviceOptionsAny
 	) {
 		super()
 

--- a/packages/timeline-state-resolver/src/conductor.ts
+++ b/packages/timeline-state-resolver/src/conductor.ts
@@ -18,33 +18,13 @@ import {
 	ResolvedTimelineObjectInstanceExtended,
 	DeviceOptionsBase,
 	Datastore,
-	DeviceOptionsTelemetrics,
 	TSRTimelineObj,
 	TSRTimeline,
 	Timeline,
 	TSRTimelineContent,
 	TimelineDatastoreReferencesContent,
-	DeviceOptionsMultiOsc,
 	TimelineDatastoreReferences,
-	DeviceOptionsObs,
-	DeviceOptionsOsc,
-	DeviceOptionsShotoku,
-	DeviceOptionsHttpSend,
-	DeviceOptionsHttpWatcher,
-	DeviceOptionsAbstract,
-	DeviceOptionsAtem,
-	DeviceOptionsTcpSend,
-	DeviceOptionsQuantel,
-	DeviceOptionsHyperdeck,
-	DeviceOptionsPanasonicPTZ,
-	DeviceOptionsLawo,
-	DeviceOptionsSofieChef,
-	DeviceOptionsPharos,
-	DeviceOptionsViscaOverIP,
-	DeviceOptionsTricaster,
-	DeviceOptionsSingularLive,
 	fillStateFromDatastore,
-	DeviceOptionsWebsocketClient,
 } from 'timeline-state-resolver-types'
 
 import { DoOnTime } from './devices/doOnTime'
@@ -55,10 +35,6 @@ import type { FinishedTrace } from 'timeline-state-resolver-api'
 import { CommandWithContext } from './service/device'
 import { DeviceContainer } from './devices/deviceContainer'
 
-import { DeviceOptionsCasparCGInternal } from './integrations/casparCG'
-import { DeviceOptionsSisyfosInternal } from './integrations/sisyfos'
-import { DeviceOptionsVMixInternal } from './integrations/vmix'
-import { DeviceOptionsVizMSEInternal } from './integrations/vizMSE'
 import { BaseRemoteDeviceIntegration } from './service/remoteDeviceInstance'
 import { ConnectionManager } from './service/ConnectionManager'
 import { DevicesRegistry } from './service/devicesRegistry'
@@ -1148,31 +1124,6 @@ export class Conductor extends EventEmitter<ConductorEvents> {
 		}
 	}
 }
-export type DeviceOptionsAnyInternal =
-	| DeviceOptionsAbstract
-	| DeviceOptionsCasparCGInternal
-	| DeviceOptionsAtem
-	| DeviceOptionsLawo
-	| DeviceOptionsHttpSend
-	| DeviceOptionsHttpWatcher
-	| DeviceOptionsPanasonicPTZ
-	| DeviceOptionsTcpSend
-	| DeviceOptionsHyperdeck
-	| DeviceOptionsPharos
-	| DeviceOptionsObs
-	| DeviceOptionsOsc
-	| DeviceOptionsMultiOsc
-	| DeviceOptionsSisyfosInternal
-	| DeviceOptionsSofieChef
-	| DeviceOptionsQuantel
-	| DeviceOptionsSingularLive
-	| DeviceOptionsVMixInternal
-	| DeviceOptionsShotoku
-	| DeviceOptionsVizMSEInternal
-	| DeviceOptionsTelemetrics
-	| DeviceOptionsTricaster
-	| DeviceOptionsViscaOverIP
-	| DeviceOptionsWebsocketClient
 
 function removeParentFromState(
 	o: Timeline.TimelineState<TSRTimelineContent>

--- a/packages/timeline-state-resolver/src/integrations/abstract/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/abstract/index.ts
@@ -3,7 +3,6 @@ import {
 	AbstractOptions,
 	Timeline,
 	TSRTimelineContent,
-	DeviceOptionsAbstract,
 	AbstractActionMethods,
 	ActionExecutionResultCode,
 	AbstractDeviceTypes,
@@ -12,8 +11,6 @@ import {
 import { Device, CommandWithContext } from '../../service/device'
 
 export type AbstractCommandWithContext = CommandWithContext<string, string>
-
-export type DeviceOptionsAbstractInternal = DeviceOptionsAbstract
 
 export type AbstractDeviceState = Timeline.TimelineState<TSRTimelineContent>
 

--- a/packages/timeline-state-resolver/src/service/ConnectionManager.ts
+++ b/packages/timeline-state-resolver/src/service/ConnectionManager.ts
@@ -1,8 +1,7 @@
-import { DeviceOptionsBase, DeviceType } from 'timeline-state-resolver-types'
+import { DeviceOptionsAny, DeviceOptionsBase, DeviceType } from 'timeline-state-resolver-types'
 import { BaseRemoteDeviceIntegration, RemoteDeviceInstance } from './remoteDeviceInstance'
 import _ = require('underscore')
 import { ThreadedClassConfig } from 'threadedclass'
-import { DeviceOptionsAnyInternal } from '../conductor'
 import { DeviceContainer } from '..//devices/deviceContainer'
 import { assertNever } from 'atem-connection/dist/lib/atemUtil'
 import { CasparCGDevice, DeviceOptionsCasparCGInternal } from '../integrations/casparCG'
@@ -40,8 +39,8 @@ export type MappedDeviceEvents = {
 export class ConnectionManager extends EventEmitter<ConnectionManagerEvents> {
 	private _devicesRegistry: DevicesRegistry
 
-	private _config: Map<string, DeviceOptionsAnyInternal> = new Map()
-	private _connections: Map<string, BaseRemoteDeviceIntegration<DeviceOptionsAnyInternal>> = new Map()
+	private _config: Map<string, DeviceOptionsAny> = new Map()
+	private _connections: Map<string, BaseRemoteDeviceIntegration<DeviceOptionsAny>> = new Map()
 	private _updating = false
 
 	private _connectionAttempts = new Map<string, { last: number; next: number }>()
@@ -56,7 +55,7 @@ export class ConnectionManager extends EventEmitter<ConnectionManagerEvents> {
 	/**
 	 * Set the config options for all connections
 	 */
-	public setConnections(connectionsConfig: Record<string, DeviceOptionsAnyInternal>) {
+	public setConnections(connectionsConfig: Record<string, DeviceOptionsAny>) {
 		// run through and see if we need to reset any of the counters
 		this._config.forEach((conf, id) => {
 			const newConf = connectionsConfig[id]
@@ -66,7 +65,7 @@ export class ConnectionManager extends EventEmitter<ConnectionManagerEvents> {
 			}
 		})
 
-		this._config = new Map(Object.entries<DeviceOptionsAnyInternal>(connectionsConfig))
+		this._config = new Map(Object.entries<DeviceOptionsAny>(connectionsConfig))
 		this._updateConnections()
 	}
 
@@ -326,10 +325,7 @@ export class ConnectionManager extends EventEmitter<ConnectionManagerEvents> {
 		}
 	}
 
-	private async _handleConnectionInitialisation(
-		id: string,
-		container: BaseRemoteDeviceIntegration<DeviceOptionsAnyInternal>
-	) {
+	private async _handleConnectionInitialisation(id: string, container: BaseRemoteDeviceIntegration<DeviceOptionsAny>) {
 		const deviceOptions = this._config.get(id)
 		if (!deviceOptions) return // if the config has been removed, the connection should be removed as well so no need to init
 
@@ -344,7 +340,7 @@ export class ConnectionManager extends EventEmitter<ConnectionManagerEvents> {
 
 	private async _setupDeviceListeners(
 		id: string,
-		container: BaseRemoteDeviceIntegration<DeviceOptionsAnyInternal>
+		container: BaseRemoteDeviceIntegration<DeviceOptionsAny>
 	): Promise<void> {
 		const passEvent = <T extends keyof DeviceInstanceEvents>(ev: T) => {
 			const evHandler: any = (...args: DeviceInstanceEvents[T]) =>
@@ -392,7 +388,7 @@ function configHasChanged(oldConfig: DeviceOptionsBase<any>, config: DeviceOptio
 
 function createContainer(
 	pluginPath: string | null,
-	deviceOptions: DeviceOptionsAnyInternal,
+	deviceOptions: DeviceOptionsAny,
 	deviceId: string,
 	getCurrentTime: () => number,
 	threadedClassOptions: ThreadedClassConfig

--- a/packages/timeline-state-resolver/src/service/DeviceInstance.ts
+++ b/packages/timeline-state-resolver/src/service/DeviceInstance.ts
@@ -12,11 +12,11 @@ import {
 import type { CommandWithContext, DeviceContextAPI, DeviceEvents } from './device'
 import { StateHandler } from './stateHandler'
 import { DevicesDict } from './devices'
-import type { DeviceOptionsAnyInternal, ExpectedPlayoutItem } from '..'
+import type { DeviceOptionsAny, ExpectedPlayoutItem } from '..'
 import type { StateChangeReport } from './measure'
 import { StateTracker } from './stateTracker'
 
-type Config = DeviceOptionsAnyInternal
+type Config = DeviceOptionsAny
 type DeviceState = any
 type AddressState = any
 

--- a/packages/timeline-state-resolver/src/service/remoteDeviceInstance.ts
+++ b/packages/timeline-state-resolver/src/service/remoteDeviceInstance.ts
@@ -1,8 +1,8 @@
 import { ThreadedClass, threadedClass, ThreadedClassConfig, ThreadedClassManager } from 'threadedclass'
-import { DeviceType, DeviceOptionsBase } from 'timeline-state-resolver-types'
+import { DeviceType, DeviceOptionsBase, DeviceOptionsAny } from 'timeline-state-resolver-types'
 import { EventEmitter } from 'eventemitter3'
 import { DeviceDetails, DeviceInstanceWrapper } from './DeviceInstance'
-import type { Device, DeviceOptionsAnyInternal } from '../conductor'
+import type { Device } from '../conductor'
 
 export type DeviceContainerEvents = {
 	error: [context: string, err: Error]
@@ -126,7 +126,7 @@ export class RemoteDeviceInstance<
 		container._device = await threadedClass<DeviceInstanceWrapper, typeof DeviceInstanceWrapper>(
 			'../../dist/service/DeviceInstance.js',
 			'DeviceInstanceWrapper',
-			[deviceId, getCurrentTime(), pluginPath, deviceOptions as DeviceOptionsAnyInternal, getCurrentTime as any], // any because callbacks can't be casted
+			[deviceId, getCurrentTime(), pluginPath, deviceOptions as DeviceOptionsAny, getCurrentTime as any], // any because callbacks can't be casted
 			threadConfig
 		)
 


### PR DESCRIPTION
## About the Contributor

This pull request is posted on behalf of the NRK.

## Type of Contribution

This is a: Code improvement


## New Behavior

This removes the remaining usages of `DeviceOptionsAnyInternal`, replacing them with `DeviceOptionsAny`.

The types that make up `DeviceOptionsAnyInternal` are internal types that provide some additional option properties over the types in `DeviceOptionsAny`. These are used solely to expose some additional hooks for unit tests, so exposing these types in the public api is a little weird.

Instead we can assume the unit tests will use the appropriate types and that things will line up fine. It is also worth noting that this is exclusively used by integrations that have not been updated to the service flow, so defining these internal types should no longer happen for new integrations.

Additionally, this further reduces the friction when adding a new integration. As there is one less type that needs to include the new integration


## Testing Instructions

<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
