### PR TITLE
fix(Sisyfos): 'mixerOnline' event was emitted continously

### DIFF
--- a/packages/timeline-state-resolver/src/integrations/sisyfos/connection.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/connection.ts
@@ -9,7 +9,7 @@ const CONNECTIVITY_TIMEOUT = 1000 // ms
 interface SisyfosApiEvents {
 	error: [Error]
 	initialized: []
-	mixerOnline: [boolean]
+	mixerOnlineChanged: []
 	connected: []
 	disconnected: []
 }
@@ -238,10 +238,6 @@ export class SisyfosApi extends EventEmitter<SisyfosApiEvents> {
 		return this._mixerOnline
 	}
 
-	setMixerOnline(state: boolean) {
-		this._mixerOnline = state
-	}
-
 	private _monitorConnectivity() {
 		const pingSisyfos = () => {
 			if (this._oscClient) this._oscClient.send({ address: `/ping/${this._pingCounter}`, args: [] })
@@ -296,12 +292,20 @@ export class SisyfosApi extends EventEmitter<SisyfosApiEvents> {
 				this._clearPingTimer()
 				this.updateIsConnected(true)
 				this._pingCounter++
-				this.emit('mixerOnline', true)
+
+				if (!this._mixerOnline) {
+					this._mixerOnline = true
+					this.emit('mixerOnlineChanged')
+				}
 			} else if (message.args[0].value === 'offline') {
 				this._clearPingTimer()
 				this.updateIsConnected(true)
 				this._pingCounter++
-				this.emit('mixerOnline', false)
+
+				if (this._mixerOnline) {
+					this._mixerOnline = false
+					this.emit('mixerOnlineChanged')
+				}
 			}
 		}
 	}

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
@@ -63,8 +63,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState, DeviceOp
 		this._sisyfos.on('disconnected', () => {
 			this._connectionChanged()
 		})
-		this._sisyfos.on('mixerOnline', (onlineStatus) => {
-			this._sisyfos.setMixerOnline(onlineStatus)
+		this._sisyfos.on('mixerOnlineChanged', () => {
 			this._connectionChanged()
 		})
 


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."

This pull request is posted on behalf of the NRK.
-->

## Type of Contribution

This is a: Bug fix 

## Current Behavior

<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

The `mixerOnline` event is emitted continuously in the Sisyfos device, which causes a log line to be written continuously.

## New Behavior

<!--
What is the new behavior?
-->

The `mixerOnline` event is only emitted upon change, logging is reduced.


## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
