### PR TITLE
Add VMix Active Input Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Using this input, it resolves the expected state, diffs the state against curren
 - **Blackmagic Design ATEM** vision mixers - using the [atem-connection](https://github.com/Sofie-Automation/sofie-atem-connection) library
 - **Blackmagic Design Hyperdeck** record/playback devices - using the [hyperdeck-connection](https://github.com/Sofie-Automation/sofie-hyperdeck-connection) library
 - **Lawo** audio mixers - using the [emberplus](https://github.com/Sofie-Automation/sofie-emberplus-connection) library
-- **[OBS Studio](https://obsproject.com/)** live video production software (currently not supporting v29)
-- **Panasoniz PTZ** cameras
+- **[OBS Studio](https://obsproject.com/)** live video production software
+- **Panasonic PTZ** cameras
 - **Pharos** light control devices
 - **[Sisyfos](https://github.com/olzzon/sisyfos-audio-controller)** audio controller
 - **Quantel** video server
@@ -32,11 +32,12 @@ Using this input, it resolves the expected state, diffs the state against curren
 - **Singular Live Graphics**
 - **[Sofie Chef](https://github.com/Sofie-Automation/sofie-chef)**
 - **Telemetrics** camera robotics
-- **Newtek Tricaster** video mixers
+- **VizRT/Newtek Tricaster** video mixers
 - **[VISCA over IP](https://en.wikipedia.org/wiki/VISCA_Protocol)** camera control
 - Arbitrary [OSC](https://en.wikipedia.org/wiki/Open_Sound_Control) compatible devices
 - Arbitrary HTTP (REST) compatible devices
 - Arbitrary TCP-socket compatible devices
+- Arbitrary WebSocket servers
 
 ## Installation and Usage
 

--- a/packages/timeline-state-resolver-types/src/generated/vmix.ts
+++ b/packages/timeline-state-resolver-types/src/generated/vmix.ts
@@ -17,17 +17,17 @@ export interface VmixOptions {
 
 export interface MappingVmixProgram {
 	/**
-	 * Number of the mix (1 is the main mix, 2-4 are optional Mix Inputs)
+	 * Number of the mix (1 is the main mix, 2-16 are optional Mix Inputs)
 	 */
-	index?: 1 | 2 | 3 | 4
+	index?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16
 	mappingType: MappingVmixType.Program
 }
 
 export interface MappingVmixPreview {
 	/**
-	 * Number of the mix (1 is the main mix, 2-4 are optional Mix Inputs)
+	 * Number of the mix (1 is the main mix, 2-16 are optional Mix Inputs)
 	 */
-	index?: 1 | 2 | 3 | 4
+	index?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16
 	mappingType: MappingVmixType.Preview
 }
 

--- a/packages/timeline-state-resolver-types/src/integrations/vmix.ts
+++ b/packages/timeline-state-resolver-types/src/integrations/vmix.ts
@@ -2,6 +2,7 @@ import { DeviceType } from '..'
 
 export enum VMixCommand {
 	PREVIEW_INPUT = 'PREVIEW_INPUT',
+	ACTIVE_INPUT = 'ACTIVE_INPUT',
 	TRANSITION = 'TRANSITION',
 
 	// input audio

--- a/packages/timeline-state-resolver/src/integrations/vmix/$schemas/mappings.json
+++ b/packages/timeline-state-resolver/src/integrations/vmix/$schemas/mappings.json
@@ -9,8 +9,8 @@
 					"type": "integer",
 					"ui:title": "Index",
 					"ui:summaryTitle": "Index",
-					"description": "Number of the mix (1 is the main mix, 2-4 are optional Mix Inputs)",
-					"enum": [1, 2, 3, 4]
+					"description": "Number of the mix (1 is the main mix, 2-16 are optional Mix Inputs)",
+					"enum": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
 				}
 			},
 			"required": [],
@@ -23,8 +23,8 @@
 					"type": "integer",
 					"ui:title": "Index",
 					"ui:summaryTitle": "Index",
-					"description": "Number of the mix (1 is the main mix, 2-4 are optional Mix Inputs)",
-					"enum": [1, 2, 3, 4]
+					"description": "Number of the mix (1 is the main mix, 2-16 are optional Mix Inputs)",
+					"enum": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
 				}
 			},
 			"required": [],

--- a/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vmix.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vmix.spec.ts
@@ -976,10 +976,8 @@ describe('vMix', () => {
 			11000,
 			expect.objectContaining({
 				command: {
-					command: VMixCommand.TRANSITION,
+					command: VMixCommand.ACTIVE_INPUT,
 					input: prefixAddedInput('C:/videos/My Clip.mp4'),
-					duration: 0,
-					effect: VMixTransitionType.Cut,
 					mix: 0,
 				},
 			}),
@@ -1005,8 +1003,8 @@ describe('vMix', () => {
 
 		expect(onFunction).toHaveBeenNthCalledWith(
 			1,
-			'Cut',
-			expect.stringContaining('Input=' + prefixAddedInput('C:/videos/My Clip.mp4') + '&Duration=0&Mix=0')
+			'ActiveInput',
+			expect.stringContaining('Input=' + prefixAddedInput('C:/videos/My Clip.mp4') + '&Mix=0')
 		)
 		expect(onFunction).toHaveBeenNthCalledWith(
 			2,
@@ -1051,10 +1049,8 @@ describe('vMix', () => {
 			16000,
 			expect.objectContaining({
 				command: {
-					command: VMixCommand.TRANSITION,
+					command: VMixCommand.ACTIVE_INPUT,
 					input: prefixAddedInput('G:/videos/My Other Clip.mp4'),
-					duration: 0,
-					effect: VMixTransitionType.Cut,
 					mix: 0,
 				},
 			}),
@@ -1102,8 +1098,8 @@ describe('vMix', () => {
 		)
 		expect(onFunction).toHaveBeenNthCalledWith(
 			3,
-			'Cut',
-			expect.stringContaining('Input=' + prefixAddedInput('G:/videos/My Other Clip.mp4') + '&Duration=0&Mix=0')
+			'ActiveInput',
+			expect.stringContaining('Input=' + prefixAddedInput('G:/videos/My Other Clip.mp4') + '&Mix=0')
 		)
 		expect(onFunction).toHaveBeenNthCalledWith(
 			4,
@@ -1583,8 +1579,22 @@ describe('vMix', () => {
 					input: 5,
 				},
 			},
+			// this preview command should work
 			{
 				id: 'preview1',
+				enable: {
+					start: 11000,
+					duration: 5000,
+				},
+				layer: 'vmix_preview1',
+				content: {
+					deviceType: DeviceType.VMIX,
+					type: TimelineContentTypeVMix.PREVIEW,
+					input: 3,
+				},
+			},
+			{
+				id: 'preview2',
 				enable: {
 					start: 11005,
 					duration: 5000,
@@ -1594,19 +1604,6 @@ describe('vMix', () => {
 					deviceType: DeviceType.VMIX,
 					type: TimelineContentTypeVMix.PREVIEW,
 					input: 'Cam 4',
-				},
-			},
-			{
-				id: 'preview2',
-				enable: {
-					start: 11005,
-					duration: 5000,
-				},
-				layer: 'vmix_preview1',
-				content: {
-					deviceType: DeviceType.VMIX,
-					type: TimelineContentTypeVMix.PREVIEW,
-					input: 3,
 				},
 			},
 			{
@@ -1647,10 +1644,8 @@ describe('vMix', () => {
 			11000,
 			expect.objectContaining({
 				command: {
-					command: VMixCommand.TRANSITION,
+					command: VMixCommand.ACTIVE_INPUT,
 					input: 5,
-					duration: 0,
-					effect: VMixTransitionType.Cut,
 					mix: 1,
 				},
 			}),
@@ -1659,12 +1654,12 @@ describe('vMix', () => {
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
 			3,
-			11005,
+			11000,
 			expect.objectContaining({
 				command: {
 					command: VMixCommand.PREVIEW_INPUT,
-					input: 'Cam 4',
-					mix: 0,
+					input: 3,
+					mix: 1,
 				},
 			}),
 			CommandContext.None,
@@ -1676,8 +1671,8 @@ describe('vMix', () => {
 			expect.objectContaining({
 				command: {
 					command: VMixCommand.PREVIEW_INPUT,
-					input: 3,
-					mix: 1,
+					input: 'Cam 4',
+					mix: 0,
 				},
 			}),
 			CommandContext.None,
@@ -1691,9 +1686,9 @@ describe('vMix', () => {
 			'VerticalSlideReverse',
 			expect.stringContaining('Input=Cam 1&Duration=1337&Mix=0')
 		)
-		expect(onFunction).toHaveBeenNthCalledWith(2, 'Cut', expect.stringContaining('Input=5&Duration=0&Mix=1'))
-		expect(onFunction).toHaveBeenNthCalledWith(3, 'PreviewInput', expect.stringContaining('Input=Cam 4&Mix=0'))
-		expect(onFunction).toHaveBeenNthCalledWith(4, 'PreviewInput', expect.stringContaining('Input=3&Mix=1'))
+		expect(onFunction).toHaveBeenNthCalledWith(2, 'ActiveInput', expect.stringContaining('Input=5&Mix=1'))
+		expect(onFunction).toHaveBeenNthCalledWith(3, 'PreviewInput', expect.stringContaining('Input=3&Mix=1'))
+		expect(onFunction).toHaveBeenNthCalledWith(4, 'PreviewInput', expect.stringContaining('Input=Cam 4&Mix=0'))
 
 		clearMocks()
 		commandReceiver0.mockClear()
@@ -3644,10 +3639,8 @@ describe('vMix', () => {
 			10105,
 			expect.objectContaining({
 				command: {
-					command: VMixCommand.TRANSITION,
-					effect: VMixTransitionType.Cut,
+					command: VMixCommand.ACTIVE_INPUT,
 					input: 1,
-					duration: 0,
 					mix: 0,
 				},
 			}),
@@ -3673,10 +3666,8 @@ describe('vMix', () => {
 			11000,
 			expect.objectContaining({
 				command: {
-					command: VMixCommand.TRANSITION,
-					effect: VMixTransitionType.Cut,
+					command: VMixCommand.ACTIVE_INPUT,
 					input: 2,
-					duration: 0,
 					mix: 0,
 				},
 			}),
@@ -3710,9 +3701,9 @@ describe('vMix', () => {
 
 		expect(onFunction).toHaveBeenCalledTimes(5)
 
-		expect(onFunction).toHaveBeenNthCalledWith(1, 'Cut', expect.stringContaining('Input=1'))
+		expect(onFunction).toHaveBeenNthCalledWith(1, 'ActiveInput', expect.stringContaining('Input=1'))
 		expect(onFunction).toHaveBeenNthCalledWith(2, 'SetMultiViewOverlay', expect.stringContaining('Input=2&Value=1,3'))
-		expect(onFunction).toHaveBeenNthCalledWith(3, 'Cut', expect.stringContaining('Input=2'))
+		expect(onFunction).toHaveBeenNthCalledWith(3, 'ActiveInput', expect.stringContaining('Input=2'))
 		expect(onFunction).toHaveBeenNthCalledWith(4, 'Pause', expect.stringContaining('Input=1'))
 		expect(onFunction).toHaveBeenNthCalledWith(5, 'ListRemoveAll', expect.stringContaining('Input=1'))
 

--- a/packages/timeline-state-resolver/src/integrations/vmix/connection.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/connection.ts
@@ -161,6 +161,8 @@ export class VMixCommandSender {
 		switch (command.command) {
 			case VMixCommand.PREVIEW_INPUT:
 				return this.setPreviewInput(command.input, command.mix)
+			case VMixCommand.ACTIVE_INPUT:
+				return this.setActiveInput(command.input, command.mix)
 			case VMixCommand.TRANSITION:
 				return this.transition(command.input, command.effect, command.duration, command.mix)
 			case VMixCommand.AUDIO_VOLUME:
@@ -275,6 +277,10 @@ export class VMixCommandSender {
 
 	public async setPreviewInput(input: number | string, mix: number): Promise<any> {
 		return this.sendCommandFunction('PreviewInput', { input, mix })
+	}
+
+	public async setActiveInput(input: number | string, mix: number): Promise<any> {
+		return this.sendCommandFunction('ActiveInput', { input, mix })
 	}
 
 	public async transition(input: number | string, effect: string, duration: number, mix: number): Promise<any> {

--- a/packages/timeline-state-resolver/src/integrations/vmix/vMixCommands.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/vMixCommands.ts
@@ -8,6 +8,11 @@ export interface VMixStateCommandPreviewInput extends VMixStateCommandBase {
 	input: number | string
 	mix: number
 }
+export interface VMixStateCommandActiveInput extends VMixStateCommandBase {
+	command: VMixCommand.ACTIVE_INPUT
+	input: number | string
+	mix: number
+}
 export interface VMixStateCommandTransition extends VMixStateCommandBase {
 	command: VMixCommand.TRANSITION
 	input: number | string
@@ -240,6 +245,7 @@ export interface VMixStateCommandSetImage extends VMixStateCommandBase {
 }
 export type VMixStateCommand =
 	| VMixStateCommandPreviewInput
+	| VMixStateCommandActiveInput
 	| VMixStateCommandTransition
 	| VMixStateCommandAudio
 	| VMixStateCommandAudioBalance

--- a/packages/timeline-state-resolver/src/integrations/vmix/vMixTimelineStateConverter.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/vMixTimelineStateConverter.ts
@@ -58,9 +58,12 @@ export class VMixTimelineStateConverter {
 			_.map(state.layers, (tlObject, layerName) => ({
 				layerName,
 				tlObject,
-				mapping: mappings[layerName],
+				mapping: mappings[layerName] as Mapping<SomeMappingVmix, DeviceType> | undefined,
 			})).sort((a, b) => a.layerName.localeCompare(b.layerName)),
-			(o) => mappingPriority[o.mapping.options.mappingType] ?? Number.POSITIVE_INFINITY
+			(o) =>
+				o.mapping
+					? mappingPriority[o.mapping?.options.mappingType] ?? Number.POSITIVE_INFINITY
+					: Number.POSITIVE_INFINITY
 		)
 
 		_.each(sortedLayers, ({ tlObject, layerName, mapping }) => {


### PR DESCRIPTION
## About the Contributor

This pull request is posted on behalf of the BBC.

## Type of Contribution

This is a: Bug fix / Feature

## Current Behavior

<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->
VMix cuts on Mixes are always done by using a Transition Command. This will replace the current on-air input with the new input and move the old input to the preview bus. 

## New Behavior

<!--
What is the new behavior?
-->
VMix cuts on Mixes are done through the Active Input Command. This will replace the current on-air input with the new input but does _not_ change the preview bus. This is similar to how the Atem integration behaves when changing the "programInput" and instead of the "input" field.

_Note: in theory today it is possible to enable an overlay on the preview input and that would be enabled by the Transition Command but will not be enabled by the newly added Active Input Command. In reality, we never supported enabling overlays in preview anyway, the use case is limited to cut commands and it only works for taking Overlays in and not out._

## Testing Instructions

<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->
- Adding any timeline objects with content type `TimelineContentTypeVMixProgram` without transition or with the transition to a Cut should result in **no** changes to the preview in VMix
- Adding any timeline objects with content type `TimelineContentTypeVMixProgram` with a transition object will still result in a Transition Command (and hence change the preview as well)

## Status

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
